### PR TITLE
odg/tasks: ODG component version is not required as part of the payload

### DIFF
--- a/pkg/odg/tasks/orphan_public_ip_gcp.go
+++ b/pkg/odg/tasks/orphan_public_ip_gcp.go
@@ -105,7 +105,12 @@ func HandleReportOrphanPublicAddressGCP(ctx context.Context, t *asynq.Task) erro
 		return nil
 	}
 
-	logger.Info("submitting orphan gcp public ip addresses to odg", "count", len(artefacts))
+	logger.Info(
+		"submitting orphan gcp public ip addresses to odg",
+		"count", len(artefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}

--- a/pkg/odg/tasks/orphan_vms_aws.go
+++ b/pkg/odg/tasks/orphan_vms_aws.go
@@ -105,7 +105,12 @@ func HandleReportOrphanVirtualMachinesAWS(ctx context.Context, t *asynq.Task) er
 		return nil
 	}
 
-	logger.Info("submitting orphan aws instances to odg", "count", len(artefacts))
+	logger.Info(
+		"submitting orphan aws instances to odg",
+		"count", len(artefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}

--- a/pkg/odg/tasks/orphan_vms_azure.go
+++ b/pkg/odg/tasks/orphan_vms_azure.go
@@ -105,7 +105,12 @@ func HandleReportOrphanVirtualMachinesAzure(ctx context.Context, t *asynq.Task) 
 		return nil
 	}
 
-	logger.Info("submitting orphan azure instances to odg", "count", len(artefacts))
+	logger.Info(
+		"submitting orphan azure instances to odg",
+		"count", len(artefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}

--- a/pkg/odg/tasks/orphan_vms_gcp.go
+++ b/pkg/odg/tasks/orphan_vms_gcp.go
@@ -104,7 +104,12 @@ func HandleReportOrphanVirtualMachinesGCP(ctx context.Context, t *asynq.Task) er
 		return nil
 	}
 
-	logger.Info("submitting orphan gcp instances to odg", "count", len(artefacts))
+	logger.Info(
+		"submitting orphan gcp instances to odg",
+		"count", len(artefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}

--- a/pkg/odg/tasks/tasks.go
+++ b/pkg/odg/tasks/tasks.go
@@ -55,11 +55,6 @@ var ErrNoQuery = errors.New("no query specified")
 // was provided.
 var ErrNoComponentName = errors.New("no component name specified")
 
-// ErrNoComponentVersion is an error, which is returned by task handlers, which
-// expect an OCM component version to be specified as part of the payload, but
-// none was provided.
-var ErrNoComponentVersion = errors.New("no component version specified")
-
 // Payload represents the payload expected by tasks which report orphan
 // resources to the Open Delivery Gear API.
 type Payload struct {
@@ -93,10 +88,6 @@ func DecodePayload(t *asynq.Task) (*Payload, error) {
 
 	if payload.ComponentName == "" {
 		return nil, ErrNoComponentName
-	}
-
-	if payload.ComponentVersion == "" {
-		return nil, ErrNoComponentVersion
 	}
 
 	return &payload, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

The ODG component version is not required to be present as part of the payload. When a finding is submitted and the component version is omitted it is considered that the finding is relevant for the component as a whole.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- component version is not required as part of the task payload
```
