### PR TITLE
Make build logs public and also fix example scheduler jobs

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -44,7 +44,7 @@ inventory-extension-odg:
           retention_policy: 'clean-snapshots'
         draft_release: ~
         options:
-          public_build_logs: false
+          public_build_logs: true
     pull-request:
       traits:
         pull-request: ~
@@ -52,7 +52,7 @@ inventory-extension-odg:
           ocm_repository_mappings:
             - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
-          public_build_logs: false
+          public_build_logs: true
     release:
       traits:
         version:

--- a/examples/scheduler/config.yaml
+++ b/examples/scheduler/config.yaml
@@ -4,7 +4,7 @@ scheduler:
   jobs:
     # AWS orphan instances
     - name: "odg:task:report-orphan-vms-aws"
-      spec: "@every 7d"
+      spec: "@every 168h"
       desc: "Report orphan AWS EC2 Instances"
       queue: odg
       payload: |
@@ -31,7 +31,7 @@ scheduler:
 
     # GCP orphan instances
     - name: "odg:task:report-orphan-vms-gcp"
-      spec: "@every 7d"
+      spec: "@every 168h"
       desc: "Report orphan GCP Virtual Machines"
       queue: odg
       payload: |
@@ -62,7 +62,7 @@ scheduler:
 
     # Azure orphan virtual machines
     - name: "odg:task:report-orphan-vms-az"
-      spec: "@every 7d"
+      spec: "@every 168h"
       desc: "Report orphan Azure Virtual Machines"
       queue: odg
       payload: |
@@ -86,7 +86,7 @@ scheduler:
 
     # GCP orphan Public IP Address
     - name: "odg:task:report-orphan-ip-addresses-gcp"
-      spec: "@every 7d"
+      spec: "@every 168h"
       desc: "Report orphan GCP Public Addresses"
       queue: odg
       payload: |


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR makes the build logs public and also fixes the example scheduler jobs.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Make build logs public
- Fix example scheduler jobs interval
```
