### PR TITLE
Replace `redis` with `valkey`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ go.work.sum
 # Local Docker volumes
 dev/local/postgres
 dev/local/redis
+dev/local/valkey

--- a/deployment/kustomize/config/files/config.yaml
+++ b/deployment/kustomize/config/files/config.yaml
@@ -18,7 +18,7 @@ logging:
 
 # Redis settings
 redis:
-  endpoint: redis:6379
+  endpoint: valkey:6379
 
 # Database settings
 database:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,14 +16,14 @@ services:
       timeout: 5s
       retries: 5
 
-  redis:
+  valkey:
     ports:
       - 6379:6379
-    image: redis:7.4-bookworm
+    image: valkey/valkey:8.1-alpine
     volumes:
-      - ./dev/local/redis:/data
+      - ./dev/local/valkey:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ["CMD", "valkey-cli", "ping"]
       interval: 5s
       timeout: 5s
       retries: 5
@@ -42,7 +42,7 @@ services:
     environment:
       INVENTORY_EXTENSION_CONFIG: /home/nonroot/config.yaml
     depends_on:
-      redis:
+      valkey:
         condition: service_healthy
       postgres:
         condition: service_healthy

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,7 +113,7 @@ make build
 ## Docker Compose
 
 You can also run a local development environment using Docker Compose, which
-will start up Redis, PostgreSQL and the extension worker for you. In order to do
+will start up Valkey, PostgreSQL and the extension worker for you. In order to do
 that, simply execute the following command.
 
 ``` shell
@@ -122,11 +122,11 @@ make docker-compose-up
 
 The services which will be started are summarized in the table below.
 
-| Service    | Description                   |
-|:-----------|:------------------------------|
-| `postgres` | PostgreSQL database           |
-| `worker`   | Inventory Extension Worker    |
-| `redis`    | Redis used as a message queue |
+| Service    | Description                    |
+|:-----------|:-------------------------------|
+| `postgres` | PostgreSQL database            |
+| `worker`   | Inventory Extension Worker     |
+| `valkey`   | Valkey used as a message queue |
 
 Once the services are up and running, you can access the following endpoints
 from your local system.
@@ -134,7 +134,7 @@ from your local system.
 | Endpoint                      | Description                 |
 |:------------------------------|:----------------------------|
 | localhost:5432                | PostgreSQL server           |
-| localhost:6379                | Redis server                |
+| localhost:6379                | Valkey server                |
 
 If you want to run any additional upstream Inventory components such as the
 `scheduler` or `dashboard`, please refer to the upstream

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -18,7 +18,7 @@ logging:
 
 # Redis settings
 redis:
-  endpoint: redis:6379
+  endpoint: valkey:6379
 
 # Database settings
 database:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR replaces `redis` with `valkey` because of the license change from BSD 3-Clause to RSALv2 and SSPLv1 on [March 20th, 2024](https://github.com/redis/redis/commit/0b34396924eca4edc524469886dc5be6c77ec4ed).

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Replace Redis with Valkey
```
