### PR TITLE
feat: add support for runtime artefacts

### DIFF
--- a/pkg/odg/api/client/client.go
+++ b/pkg/odg/api/client/client.go
@@ -424,6 +424,39 @@ func (c *Client) QueryRuntimeArtefacts(ctx context.Context, labels map[string]st
 	return result, nil
 }
 
+// DeleteRuntimeArtefacts deletes the runtime artefacts with the specified names
+// from the Delivery Service API.
+func (c *Client) DeleteRuntimeArtefacts(ctx context.Context, names ...string) error {
+	u, err := url.JoinPath(c.endpoint.String(), "/service-extensions/runtime-artefacts")
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodDelete, u, nil)
+	if err != nil {
+		return err
+	}
+	c.setReqHeaders(req)
+
+	query := req.URL.Query()
+	for _, name := range names {
+		query.Add("name", name)
+	}
+	req.URL.RawQuery = query.Encode()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		return APIErrorFromResponse(resp)
+	}
+
+	return nil
+}
+
 // SubmitRuntimeArtefact submits the given [apitypes.ComponentArtefactID] items
 // to the Delivery Service API as runtime artefacts.
 func (c *Client) SubmitRuntimeArtefact(ctx context.Context, items ...apitypes.ComponentArtefactID) error {

--- a/pkg/odg/api/client/client.go
+++ b/pkg/odg/api/client/client.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"net/http/cookiejar"
 	"net/url"
+	"strings"
 
 	apitypes "github.com/gardener/inventory-extension-odg/pkg/odg/api/types"
 )
@@ -396,7 +397,8 @@ func (c *Client) QueryRuntimeArtefacts(ctx context.Context, labels map[string]st
 	// Filter runtime artefacts by label, if specified.
 	query := req.URL.Query()
 	for k, v := range labels {
-		query.Add("label", fmt.Sprintf("%s:%s", k, v))
+		normalizedV := strings.ReplaceAll(v, "/", "_")
+		query.Add("label", fmt.Sprintf("%s:%s", k, normalizedV))
 	}
 	req.URL.RawQuery = query.Encode()
 
@@ -489,7 +491,8 @@ func (c *Client) SubmitRuntimeArtefact(ctx context.Context, labels map[string]st
 
 	query := req.URL.Query()
 	for k, v := range labels {
-		query.Add("label", fmt.Sprintf("%s:%s", k, v))
+		normalizedV := strings.ReplaceAll(v, "/", "_")
+		query.Add("label", fmt.Sprintf("%s:%s", k, normalizedV))
 	}
 	req.URL.RawQuery = query.Encode()
 

--- a/pkg/odg/api/client/client.go
+++ b/pkg/odg/api/client/client.go
@@ -379,6 +379,45 @@ func (c *Client) SubmitArtefactMetadata(ctx context.Context, items ...apitypes.A
 	return nil
 }
 
+// SubmitRuntimeArtefact submits the given [apitypes.ComponentArtefactID] items
+// to the Delivery Service API as runtime artefacts.
+func (c *Client) SubmitRuntimeArtefact(ctx context.Context, items ...apitypes.ComponentArtefactID) error {
+	if len(items) == 0 {
+		return nil
+	}
+
+	u, err := url.JoinPath(c.endpoint.String(), "/service-extensions/runtime-artefacts")
+	if err != nil {
+		return err
+	}
+
+	payload := apitypes.RuntimeArtefactGroup{
+		Artefacts: items,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, u, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	c.setReqHeaders(req)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return APIErrorFromResponse(resp)
+	}
+
+	return nil
+}
+
 // WithGithubAuthentication configures the [Client] to authenticate against the
 // remote Delivery Service using a Github access token.
 //

--- a/pkg/odg/api/client/client.go
+++ b/pkg/odg/api/client/client.go
@@ -427,6 +427,10 @@ func (c *Client) QueryRuntimeArtefacts(ctx context.Context, labels map[string]st
 // DeleteRuntimeArtefacts deletes the runtime artefacts with the specified names
 // from the Delivery Service API.
 func (c *Client) DeleteRuntimeArtefacts(ctx context.Context, names ...string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
 	u, err := url.JoinPath(c.endpoint.String(), "/service-extensions/runtime-artefacts")
 	if err != nil {
 		return err

--- a/pkg/odg/api/client/client.go
+++ b/pkg/odg/api/client/client.go
@@ -408,7 +408,7 @@ func (c *Client) QueryRuntimeArtefacts(ctx context.Context, labels map[string]st
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+	if resp.StatusCode != http.StatusOK {
 		return nil, APIErrorFromResponse(resp)
 	}
 

--- a/pkg/odg/api/client/client.go
+++ b/pkg/odg/api/client/client.go
@@ -463,7 +463,7 @@ func (c *Client) DeleteRuntimeArtefacts(ctx context.Context, names ...string) er
 
 // SubmitRuntimeArtefact submits the given [apitypes.ComponentArtefactID] items
 // to the Delivery Service API as runtime artefacts.
-func (c *Client) SubmitRuntimeArtefact(ctx context.Context, items ...apitypes.ComponentArtefactID) error {
+func (c *Client) SubmitRuntimeArtefact(ctx context.Context, labels map[string]string, items ...apitypes.ComponentArtefactID) error {
 	if len(items) == 0 {
 		return nil
 	}
@@ -486,6 +486,12 @@ func (c *Client) SubmitRuntimeArtefact(ctx context.Context, items ...apitypes.Co
 		return err
 	}
 	c.setReqHeaders(req)
+
+	query := req.URL.Query()
+	for k, v := range labels {
+		query.Add("label", fmt.Sprintf("%s:%s", k, v))
+	}
+	req.URL.RawQuery = query.Encode()
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/pkg/odg/api/types/types.go
+++ b/pkg/odg/api/types/types.go
@@ -188,3 +188,26 @@ type ComponentArtefactIDGroup struct {
 type RuntimeArtefactGroup struct {
 	Artefacts []ComponentArtefactID `json:"artefacts"`
 }
+
+// RuntimeArtefactMetadata represents the metadata for a runtime artefact as
+// retrieved from the remote Delivery Service API.
+type RuntimeArtefactMetadata struct {
+	Name              string            `json:"name,omitempty"`
+	UID               string            `json:"uid,omitempty"`
+	Labels            map[string]string `json:"labels,omitempty"`
+	CreationTimestamp time.Time         `json:"creationTimestamp"`
+}
+
+// RuntimeArtefactSpec represents the spec for a runtime artefact as retrieved
+// from the remote Delivery Service API.
+type RuntimeArtefactSpec struct {
+	CreationData time.Time           `json:"creation_date"`
+	Artefact     ComponentArtefactID `json:"artefact"`
+}
+
+// RuntimeArtefactResultItem represents a runtime artefact retrieved from the
+// remote Delivery Service API.
+type RuntimeArtefactResultItem struct {
+	Metadata RuntimeArtefactMetadata `json:"metadata"`
+	Spec     RuntimeArtefactSpec     `json:"spec"`
+}

--- a/pkg/odg/api/types/types.go
+++ b/pkg/odg/api/types/types.go
@@ -61,6 +61,10 @@ type Datatype string
 const (
 	// DatatypeInventory represents a finding from the Inventory system
 	DatatypeInventory Datatype = "finding/inventory"
+
+	// DatatypeArtefactScanInfo is a meta artefact, which represents that a
+	// scan from given datasource has been performed.
+	DatatypeArtefactScanInfo = "meta/artefact_scan_info"
 )
 
 // ResourceKind represents the kind of orphan resource, which will be submitted
@@ -177,4 +181,10 @@ type ArtefactMetadataGroup struct {
 type ComponentArtefactIDGroup struct {
 	// Entries contains the group of [ComponentArtefactID] items.
 	Entries []ComponentArtefactID `json:"entries"`
+}
+
+// RuntimeArtefactGroup represents a group of [ComponentArtefactID] items, which
+// are submitted to the Delivery Service API as `runtime-artefacts'.
+type RuntimeArtefactGroup struct {
+	Artefacts []ComponentArtefactID `json:"artefacts"`
 }

--- a/pkg/odg/tasks/orphan_public_ip_gcp.go
+++ b/pkg/odg/tasks/orphan_public_ip_gcp.go
@@ -43,7 +43,9 @@ func HandleReportOrphanPublicAddressGCP(ctx context.Context, t *asynq.Task) erro
 
 	now := time.Now()
 	artefacts := make([]apitypes.ArtefactMetadata, 0)
+	runtimeArtefacts := make([]apitypes.ComponentArtefactID, 0)
 	for _, item := range items {
+		// Finding item
 		artefact := apitypes.ArtefactMetadata{
 			Meta: apitypes.Metadata{
 				Datasource:   apitypes.DatasourceInventory,
@@ -75,7 +77,49 @@ func HandleReportOrphanPublicAddressGCP(ctx context.Context, t *asynq.Task) erro
 			},
 			DiscoveryDate: civil.DateOf(now),
 		}
-		artefacts = append(artefacts, artefact)
+
+		// Scan info item for each finding
+		scanInfo := apitypes.ArtefactMetadata{
+			Meta: apitypes.Metadata{
+				Datasource:   apitypes.DatasourceInventory,
+				Type:         apitypes.DatatypeArtefactScanInfo,
+				CreationDate: now,
+				LastUpdate:   now,
+			},
+			Artefact: apitypes.ComponentArtefactID{
+				ComponentName:    payload.ComponentName,
+				ComponentVersion: payload.ComponentVersion,
+				Artefact: apitypes.LocalArtefactID{
+					ArtefactName:    item.Name,
+					ArtefactType:    string(apitypes.ResourceKindIPAddressGCP),
+					ArtefactVersion: payload.ComponentVersion,
+					ArtefactExtraID: map[string]string{
+						"project_id":      item.ProjectID,
+						"forwarding_rule": item.Name,
+					},
+				},
+				ArtefactKind: apitypes.ArtefactKindRuntime,
+			},
+			DiscoveryDate: civil.DateOf(now),
+		}
+		artefacts = append(artefacts, artefact, scanInfo)
+
+		// Runtime artefact item for each finding
+		runtimeArtefact := apitypes.ComponentArtefactID{
+			ComponentName:    payload.ComponentName,
+			ComponentVersion: payload.ComponentVersion,
+			Artefact: apitypes.LocalArtefactID{
+				ArtefactName:    item.Name,
+				ArtefactType:    string(apitypes.ResourceKindIPAddressGCP),
+				ArtefactVersion: payload.ComponentVersion,
+				ArtefactExtraID: map[string]string{
+					"project_id":      item.ProjectID,
+					"forwarding_rule": item.Name,
+				},
+			},
+			ArtefactKind: apitypes.ArtefactKindRuntime,
+		}
+		runtimeArtefacts = append(runtimeArtefacts, runtimeArtefact)
 	}
 
 	// 2. Wipe out old/previous findings for the artefact type
@@ -100,18 +144,45 @@ func HandleReportOrphanPublicAddressGCP(ctx context.Context, t *asynq.Task) erro
 		return MaybeSkipRetry(err)
 	}
 
-	// 3. Submit orphan resources from step 1.
-	if len(artefacts) == 0 {
-		return nil
+	// ... also wipe out old runtime artefacts
+	labels := map[string]string{
+		"created-by":    string(apitypes.DatasourceInventory),
+		"resource-kind": string(apitypes.ResourceKindIPAddressGCP),
+	}
+	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
+	if err != nil {
+		return MaybeSkipRetry(err)
 	}
 
+	logger.Info("deleting old orphan runtime artefacts from odg", "count", len(oldRuntimeArtefacts))
+	runtimeArtefactNames := make([]string, 0)
+	for _, raItem := range oldRuntimeArtefacts {
+		runtimeArtefactNames = append(runtimeArtefactNames, raItem.Metadata.Name)
+	}
+	if err := odgclient.Client.DeleteRuntimeArtefacts(ctx, runtimeArtefactNames...); err != nil {
+		return MaybeSkipRetry(err)
+	}
+
+	// 3. Submit orphan resources from step 1.
 	logger.Info(
 		"submitting orphan gcp public ip addresses to odg",
-		"count", len(artefacts),
+		"count", len(items),
 		"component_name", payload.ComponentName,
 		"component_version", payload.ComponentVersion,
 	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
+		return MaybeSkipRetry(err)
+	}
+
+	// 4. Submit runtime artefacts
+	logger.Info(
+		"submitting runtime artefacts",
+		"count", len(runtimeArtefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
+
+	if err := odgclient.Client.SubmitRuntimeArtefact(ctx, labels, runtimeArtefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}
 

--- a/pkg/odg/tasks/orphan_vms_azure.go
+++ b/pkg/odg/tasks/orphan_vms_azure.go
@@ -42,7 +42,9 @@ func HandleReportOrphanVirtualMachinesAzure(ctx context.Context, t *asynq.Task) 
 
 	now := time.Now()
 	artefacts := make([]apitypes.ArtefactMetadata, 0)
+	runtimeArtefacts := make([]apitypes.ComponentArtefactID, 0)
 	for _, item := range items {
+		// Finding item
 		artefact := apitypes.ArtefactMetadata{
 			Meta: apitypes.Metadata{
 				Datasource:   apitypes.DatasourceInventory,
@@ -75,7 +77,51 @@ func HandleReportOrphanVirtualMachinesAzure(ctx context.Context, t *asynq.Task) 
 			},
 			DiscoveryDate: civil.DateOf(now),
 		}
-		artefacts = append(artefacts, artefact)
+
+		// Scan info item for each finding
+		scanInfo := apitypes.ArtefactMetadata{
+			Meta: apitypes.Metadata{
+				Datasource:   apitypes.DatasourceInventory,
+				Type:         apitypes.DatatypeArtefactScanInfo,
+				CreationDate: now,
+				LastUpdate:   now,
+			},
+			Artefact: apitypes.ComponentArtefactID{
+				ComponentName:    payload.ComponentName,
+				ComponentVersion: payload.ComponentVersion,
+				Artefact: apitypes.LocalArtefactID{
+					ArtefactName:    item.Name,
+					ArtefactType:    string(apitypes.ResourceKindVirtualMachineAzure),
+					ArtefactVersion: payload.ComponentVersion,
+					ArtefactExtraID: map[string]string{
+						"subscription_id": item.SubscriptionID,
+						"resource_group":  item.ResourceGroup,
+						"location":        item.Location,
+					},
+				},
+				ArtefactKind: apitypes.ArtefactKindRuntime,
+			},
+			DiscoveryDate: civil.DateOf(now),
+		}
+		artefacts = append(artefacts, artefact, scanInfo)
+
+		// Runtime artefact for each finding
+		runtimeArtefact := apitypes.ComponentArtefactID{
+			ComponentName:    payload.ComponentName,
+			ComponentVersion: payload.ComponentVersion,
+			Artefact: apitypes.LocalArtefactID{
+				ArtefactName:    item.Name,
+				ArtefactType:    string(apitypes.ResourceKindVirtualMachineAzure),
+				ArtefactVersion: payload.ComponentVersion,
+				ArtefactExtraID: map[string]string{
+					"subscription_id": item.SubscriptionID,
+					"resource_group":  item.ResourceGroup,
+					"location":        item.Location,
+				},
+			},
+			ArtefactKind: apitypes.ArtefactKindRuntime,
+		}
+		runtimeArtefacts = append(runtimeArtefacts, runtimeArtefact)
 	}
 
 	// 2. Wipe out old/previous findings for the artefact type
@@ -100,18 +146,45 @@ func HandleReportOrphanVirtualMachinesAzure(ctx context.Context, t *asynq.Task) 
 		return MaybeSkipRetry(err)
 	}
 
-	// 3. Submit orphan resources from step 1.
-	if len(artefacts) == 0 {
-		return nil
+	// ... also wipe out old runtime artefacts
+	labels := map[string]string{
+		"created-by":    string(apitypes.DatasourceInventory),
+		"resource-kind": string(apitypes.ResourceKindVirtualMachineAzure),
+	}
+	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
+	if err != nil {
+		return MaybeSkipRetry(err)
 	}
 
+	logger.Info("deleting old orphan runtime artefacts from odg", "count", len(oldRuntimeArtefacts))
+	runtimeArtefactNames := make([]string, 0)
+	for _, raItem := range oldRuntimeArtefacts {
+		runtimeArtefactNames = append(runtimeArtefactNames, raItem.Metadata.Name)
+	}
+	if err := odgclient.Client.DeleteRuntimeArtefacts(ctx, runtimeArtefactNames...); err != nil {
+		return MaybeSkipRetry(err)
+	}
+
+	// 3. Submit orphan resources from step 1.
 	logger.Info(
 		"submitting orphan azure instances to odg",
-		"count", len(artefacts),
+		"count", len(items),
 		"component_name", payload.ComponentName,
 		"component_version", payload.ComponentVersion,
 	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
+		return MaybeSkipRetry(err)
+	}
+
+	// 4. Submit runtime artefact
+	logger.Info(
+		"submitting runtime artefacts",
+		"count", len(runtimeArtefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
+
+	if err := odgclient.Client.SubmitRuntimeArtefact(ctx, labels, runtimeArtefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}
 

--- a/pkg/odg/tasks/orphan_vms_gcp.go
+++ b/pkg/odg/tasks/orphan_vms_gcp.go
@@ -42,7 +42,9 @@ func HandleReportOrphanVirtualMachinesGCP(ctx context.Context, t *asynq.Task) er
 
 	now := time.Now()
 	artefacts := make([]apitypes.ArtefactMetadata, 0)
+	runtimeArtefacts := make([]apitypes.ComponentArtefactID, 0)
 	for _, item := range items {
+		// Finding item
 		artefact := apitypes.ArtefactMetadata{
 			Meta: apitypes.Metadata{
 				Datasource:   apitypes.DatasourceInventory,
@@ -74,7 +76,49 @@ func HandleReportOrphanVirtualMachinesGCP(ctx context.Context, t *asynq.Task) er
 			},
 			DiscoveryDate: civil.DateOf(now),
 		}
-		artefacts = append(artefacts, artefact)
+
+		// Scan info item for each finding
+		scanInfo := apitypes.ArtefactMetadata{
+			Meta: apitypes.Metadata{
+				Datasource:   apitypes.DatasourceInventory,
+				Type:         apitypes.DatatypeArtefactScanInfo,
+				CreationDate: now,
+				LastUpdate:   now,
+			},
+			Artefact: apitypes.ComponentArtefactID{
+				ComponentName:    payload.ComponentName,
+				ComponentVersion: payload.ComponentVersion,
+				Artefact: apitypes.LocalArtefactID{
+					ArtefactName:    item.Name,
+					ArtefactType:    string(apitypes.ResourceKindVirtualMachineGCP),
+					ArtefactVersion: payload.ComponentVersion,
+					ArtefactExtraID: map[string]string{
+						"instance_id": strconv.FormatUint(item.InstanceID, 10),
+						"project_id":  item.ProjectID,
+					},
+				},
+				ArtefactKind: apitypes.ArtefactKindRuntime,
+			},
+			DiscoveryDate: civil.DateOf(now),
+		}
+		artefacts = append(artefacts, artefact, scanInfo)
+
+		// Rutime artefact for each finding
+		runtimeArtefact := apitypes.ComponentArtefactID{
+			ComponentName:    payload.ComponentName,
+			ComponentVersion: payload.ComponentVersion,
+			Artefact: apitypes.LocalArtefactID{
+				ArtefactName:    item.Name,
+				ArtefactType:    string(apitypes.ResourceKindVirtualMachineGCP),
+				ArtefactVersion: payload.ComponentVersion,
+				ArtefactExtraID: map[string]string{
+					"instance_id": strconv.FormatUint(item.InstanceID, 10),
+					"project_id":  item.ProjectID,
+				},
+			},
+			ArtefactKind: apitypes.ArtefactKindRuntime,
+		}
+		runtimeArtefacts = append(runtimeArtefacts, runtimeArtefact)
 	}
 
 	// 2. Wipe out old/previous findings for the artefact type
@@ -99,18 +143,45 @@ func HandleReportOrphanVirtualMachinesGCP(ctx context.Context, t *asynq.Task) er
 		return MaybeSkipRetry(err)
 	}
 
-	// 3. Submit orphan resources from step 1.
-	if len(artefacts) == 0 {
-		return nil
+	// ... also wipe out old runtime artefacts
+	labels := map[string]string{
+		"created-by":    string(apitypes.DatasourceInventory),
+		"resource-kind": string(apitypes.ResourceKindVirtualMachineGCP),
+	}
+	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
+	if err != nil {
+		return MaybeSkipRetry(err)
 	}
 
+	logger.Info("deleting old orphan runtime artefacts from odg", "count", len(oldRuntimeArtefacts))
+	runtimeArtefactNames := make([]string, 0)
+	for _, raItem := range oldRuntimeArtefacts {
+		runtimeArtefactNames = append(runtimeArtefactNames, raItem.Metadata.Name)
+	}
+	if err := odgclient.Client.DeleteRuntimeArtefacts(ctx, runtimeArtefactNames...); err != nil {
+		return MaybeSkipRetry(err)
+	}
+
+	// 3. Submit orphan resources from step 1.
 	logger.Info(
 		"submitting orphan gcp instances to odg",
-		"count", len(artefacts),
+		"count", len(items),
 		"component_name", payload.ComponentName,
 		"component_version", payload.ComponentVersion,
 	)
 	if err := odgclient.Client.SubmitArtefactMetadata(ctx, artefacts...); err != nil {
+		return MaybeSkipRetry(err)
+	}
+
+	// 4. Submit runtime artefacts
+	logger.Info(
+		"submitting runtime artefacts",
+		"count", len(runtimeArtefacts),
+		"component_name", payload.ComponentName,
+		"component_version", payload.ComponentVersion,
+	)
+
+	if err := odgclient.Client.SubmitRuntimeArtefact(ctx, labels, runtimeArtefacts...); err != nil {
 		return MaybeSkipRetry(err)
 	}
 

--- a/pkg/odg/tasks/tasks.go
+++ b/pkg/odg/tasks/tasks.go
@@ -19,10 +19,15 @@
 // entries exist in the database, since the Delivery Service does not
 // have a retention mechanism for cleaning up such findings.
 //
+// Also, we need to delete old/previous runtime artefacts for each finding.
+//
 // 3. Submit the orphan resources from step 1
 //
 // The latest orphan resources fetched from step 1 are submitted to the
 // Delivery Service API.
+//
+// 4. Create runtime artefacts, so that findings can be evaluated and compliance
+// issues created or updated for them.
 //
 // If we have no orphan resources to report, then we don't report anything to
 // the remote API.


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for querying/submitting/deleting runtime artefacts via the Delivery Service API.

When we submit new findings we should also create the respective scan info + runtime artefact, so that compliance issues can be managed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
- Add support for scan info + runtime artefacts
```
