### PR TITLE
odg/tasks: add `component-name` to the set of labels for runtime artefacts

### DIFF
--- a/pkg/odg/tasks/orphan_public_ip_gcp.go
+++ b/pkg/odg/tasks/orphan_public_ip_gcp.go
@@ -146,8 +146,9 @@ func HandleReportOrphanPublicAddressGCP(ctx context.Context, t *asynq.Task) erro
 
 	// ... also wipe out old runtime artefacts
 	labels := map[string]string{
-		"created-by":    string(apitypes.DatasourceInventory),
-		"resource-kind": string(apitypes.ResourceKindIPAddressGCP),
+		"created-by":     string(apitypes.DatasourceInventory),
+		"resource-kind":  string(apitypes.ResourceKindIPAddressGCP),
+		"component-name": payload.ComponentName,
 	}
 	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
 	if err != nil {

--- a/pkg/odg/tasks/orphan_vms_aws.go
+++ b/pkg/odg/tasks/orphan_vms_aws.go
@@ -148,8 +148,9 @@ func HandleReportOrphanVirtualMachinesAWS(ctx context.Context, t *asynq.Task) er
 
 	// ... also wipe out old runtime artefacts
 	labels := map[string]string{
-		"created-by":    string(apitypes.DatasourceInventory),
-		"resource-kind": string(apitypes.ResourceKindVirtualMachineAWS),
+		"created-by":     string(apitypes.DatasourceInventory),
+		"resource-kind":  string(apitypes.ResourceKindVirtualMachineAWS),
+		"component-name": payload.ComponentName,
 	}
 	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
 	if err != nil {

--- a/pkg/odg/tasks/orphan_vms_azure.go
+++ b/pkg/odg/tasks/orphan_vms_azure.go
@@ -148,8 +148,9 @@ func HandleReportOrphanVirtualMachinesAzure(ctx context.Context, t *asynq.Task) 
 
 	// ... also wipe out old runtime artefacts
 	labels := map[string]string{
-		"created-by":    string(apitypes.DatasourceInventory),
-		"resource-kind": string(apitypes.ResourceKindVirtualMachineAzure),
+		"created-by":     string(apitypes.DatasourceInventory),
+		"resource-kind":  string(apitypes.ResourceKindVirtualMachineAzure),
+		"component-name": payload.ComponentName,
 	}
 	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
 	if err != nil {

--- a/pkg/odg/tasks/orphan_vms_gcp.go
+++ b/pkg/odg/tasks/orphan_vms_gcp.go
@@ -145,8 +145,9 @@ func HandleReportOrphanVirtualMachinesGCP(ctx context.Context, t *asynq.Task) er
 
 	// ... also wipe out old runtime artefacts
 	labels := map[string]string{
-		"created-by":    string(apitypes.DatasourceInventory),
-		"resource-kind": string(apitypes.ResourceKindVirtualMachineGCP),
+		"created-by":     string(apitypes.DatasourceInventory),
+		"resource-kind":  string(apitypes.ResourceKindVirtualMachineGCP),
+		"component-name": payload.ComponentName,
 	}
 	oldRuntimeArtefacts, err := odgclient.Client.QueryRuntimeArtefacts(ctx, labels)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds `component-name` to the set of labels for the runtime artefacts we create via the Delivery Service.

This way runtime artefacts submitted by different instances won't overlap with each other, since they will be scoped by the component name.


**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Add `component-name` to the set of labels for runtime artefacts
```
