### PR TITLE
github/workflows: fix permissions for `release-and-bump` job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
   release-and-bump:
     uses: gardener/cc-utils/.github/workflows/release.yaml@master
     permissions:
-      contents: read
+      contents: write
       packages: write
       id-token: write
       pull-requests: write


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
