### PR TITLE
deployment/kustomize/worker: expose metrics port

### DIFF
--- a/deployment/kustomize/worker/deployment.yaml
+++ b/deployment/kustomize/worker/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           capabilities:
             drop:
             - "ALL"
+        ports:
+          - containerPort: 6080
         command:
           - /app/inventory-extension-odg
         args:


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes the metrics server port for worker.

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Expose metrics port
```
