### PR TITLE
workflows: inherit secrets from re-usable workflows

### DIFF
--- a/.github/workflows/oci-images.yaml
+++ b/.github/workflows/oci-images.yaml
@@ -30,6 +30,7 @@ jobs:
       id-token: write
       pull-requests: write
     uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
+    secrets: inherit
     with:
       name: inventory-extension-odg
       version: ${{ needs.prepare.outputs.version }}


### PR DESCRIPTION
**What this PR does / why we need it**:

When building a Docker image we inherit the secrets, so that we can avoid docker.io rate limiting.

See [1] for more details.

[1]: gardener/cc-utils#1266

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
workflows: inherit secrets from oci-ocm reusable workflow
```
