### PR TITLE
Switch to OIDC Federation Service instead of GitHub App

### DIFF
--- a/.github/workflows/oci-images.yaml
+++ b/.github/workflows/oci-images.yaml
@@ -14,10 +14,7 @@ jobs:
   prepare:
     uses: gardener/cc-utils/.github/workflows/prepare.yaml@master
     permissions:
-      contents: read
-      packages: write
       id-token: write
-      pull-requests: write
     with:
       mode: ${{ inputs.mode }}
 
@@ -28,7 +25,6 @@ jobs:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     uses: gardener/cc-utils/.github/workflows/oci-ocm.yaml@master
     secrets: inherit
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,19 +5,19 @@ on:
 jobs:
   test:
     uses: ./.github/workflows/test.yaml
+    secrets: inherit
     permissions:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
 
   publish-oci:
     uses: ./.github/workflows/oci-images.yaml
+    secrets: inherit
     permissions:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     needs:
       - test
     with:
@@ -29,11 +29,8 @@ jobs:
       contents: write
       packages: write
       id-token: write
-      pull-requests: write
     needs:
       - publish-oci
-    secrets:
-      github-app-secret-key: ${{ secrets.GARDENER_GITHUB_ACTIONS_PRIVATE_KEY }}
     with:
       release-commit-target: branch
       next-version: bump-patch

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -35,11 +35,11 @@ jobs:
   publish-oci:
     if: github.event_name == 'push' && github.repository == 'gardener/inventory-extension-odg'
     uses: ./.github/workflows/oci-images.yaml
+    secrets: inherit
     permissions:
       contents: read
       packages: write
       id-token: write
-      pull-requests: write
     needs:
       - test
     with:


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the [Gardener GitHub-Actions App](https://github.com/apps/gardener-github-actions) is used to provide more privileged access than available via the default `GITHUB_TOKEN`, for example to circumvent branch protection rules (GitHub Apps can be configured as bypassers) or cross repository privileges. To prevent sharing the GitHub App secret with each and every repository/workflow which requires usage of it, the [GitHub OIDC Federation Service](https://github.com/gardener/github-oidc-federation) has been developed. In essence, it holds the credentials for a central GitHub App and creates short-lived access tokens with a configured scope based on a centrally configured OIDC configuration. See related changes which have been necessary for this repository:

- https://github.com/gardener/.github-oidc/commit/0e0f32ce04efaac83148922328d5e2254e61d782

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
